### PR TITLE
adding some notes and additional example to 06a_. Example points out …

### DIFF
--- a/06a_Path_Parma_validation_n_metadata.py
+++ b/06a_Path_Parma_validation_n_metadata.py
@@ -19,16 +19,24 @@ async def read_items(
     item_id: Annotated[int, Path(title = "The ID of the item to get")],
     q: Annotated[str | None, Query(alias = "item-query")] = None,   # ** Use of Query(alias="new-name") changes the QP's name that is to be entered in the browser. **
 ):
+    ''' Order matters. In this path operation the first parameter is not assigned a default value where as the second one is. This order is allowed.'''
     results = {"item_id": item_id}
     if q:
         results.update({"q": q})
     return results
 
 
-# Path Operation
-@app.get("/items2/")     # HTTP method decorator, with Path Parameter
-async def read_items2():
-    pass
+# @app.get("/items_2/{item_id}/")
+# async def read_items(
+#     q: Annotated[str | None, Query(alias = "item-query")] = None,
+#     item_id: Annotated[int, Path(title = "The ID of the item to get")],
+# ):
+    ''' This example is not allowed. In the above parameters, Path Parameters and Query Parameters, the first parameter, q, is assigned a default value while the subsequent parameter, item_id, is not.
+    This order is not allowed.'''
+#     results = {"item_id": item_id}
+#     if q:
+#         results.update({"q": q})
+#     return results
 
     
 def main():


### PR DESCRIPTION
…the order of the parameters within Path Operations matter when default values are concerned.